### PR TITLE
feat: add Codex security guidance (CODEX.md) and link from README

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,36 @@
+# The Side Quest (Codex Notes)
+
+This file contains project guidance for Codex agents working in this repository.
+
+## Quick start
+
+```bash
+make install
+make server   # static app at http://localhost:8044
+```
+
+For local API + scores:
+
+```bash
+make dev      # runs via Vercel dev
+```
+
+## Security checklist for Codex changes
+
+- Keep score APIs constrained to expected payload shapes (numeric score, bounded player name length).
+- Never commit secrets (`.env.local`, KV tokens, API keys) or hardcode credentials in source.
+- Prefer server-side validation in `api/scores.js` for all user-provided input.
+- Avoid introducing dynamic code execution (`eval`, `Function`, or unsanitized HTML injection).
+- If adding dependencies, choose actively maintained packages and run:
+
+```bash
+npm audit --omit=dev
+```
+
+## Project layout
+
+- `index.html` — app shell and script/style includes.
+- `styles/global.css` — game and UI styling.
+- `config.js` — user-facing text/config.
+- `scripts/game.js` — gameplay loop and rendering.
+- `api/scores.js` — serverless leaderboard API.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 <br>
 
+- **[CODEX.md](CODEX.md)** — Codex-oriented project notes with a security checklist for safe code and API changes.
+
+<br>
+
 - start the local development server at **[`localhost:8044`](http://localhost:8044)**:
 
 ```bash


### PR DESCRIPTION
### Motivation
- Provide Codex-oriented project notes and a concise security checklist to guide safe code and API changes by automated agents.
- Improve discoverability of those guidelines by linking them from the top-level `README.md` alongside existing assistant docs.

### Description
- Add a new `CODEX.md` containing quick-start instructions and a security checklist covering input validation, secret handling, server-side validation, avoiding dynamic code execution, and dependency audit guidance.
- Include a suggested `npm audit --omit=dev` step in the checklist for dependency vetting and note the expected project layout for quick reference.
- Update `README.md` to surface `CODEX.md` next to `CLAUDE.md` so Codex guidance is visible to contributors.

### Testing
- Attempted to run `npm audit --omit=dev` to validate dependencies, but the audit step failed due to a `403 Forbidden` response from the registry advisory endpoint in this environment.
- No other automated tests were run as this change is documentation-only and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3759e868832e9d44d531013f1d69)